### PR TITLE
유튜브 채널 영상 자동 임포트 기능 추가

### DIFF
--- a/.github/scripts/youtube-import.py
+++ b/.github/scripts/youtube-import.py
@@ -1,0 +1,205 @@
+import os
+import re
+import datetime
+import pytz
+import yaml
+import frontmatter
+from pathlib import Path
+from googleapiclient.discovery import build
+
+# YouTube API 설정
+API_KEY = os.environ.get('YOUTUBE_API_KEY')
+CHANNEL_ID = os.environ.get('CHANNEL_ID')
+youtube = build('youtube', 'v3', developerKey=API_KEY)
+
+# 한국 시간대 설정
+KST = pytz.timezone('Asia/Seoul')
+
+# 콘텐츠 디렉토리 설정
+CONTENT_DIR = Path('piesp-blog/content')
+VIDEOS_DIR = CONTENT_DIR / 'videos'
+VIDEOS_DIR.mkdir(exist_ok=True, parents=True)
+
+def sanitize_filename(title):
+    """파일 이름으로 사용할 수 있도록 제목 변환"""
+    # 특수 문자 제거 및 공백을 하이픈으로 변경
+    filename = re.sub(r'[^\w\s-]', '', title.lower())
+    filename = re.sub(r'[\s]+', '-', filename)
+    return filename
+
+def get_channel_uploads():
+    """채널의 업로드 재생목록 ID 가져오기"""
+    channel_response = youtube.channels().list(
+        part='contentDetails',
+        id=CHANNEL_ID
+    ).execute()
+    
+    if 'items' in channel_response and channel_response['items']:
+        return channel_response['items'][0]['contentDetails']['relatedPlaylists']['uploads']
+    return None
+
+def get_video_details(video_id):
+    """영상의 세부 정보 가져오기"""
+    video_response = youtube.videos().list(
+        part='snippet,contentDetails',
+        id=video_id
+    ).execute()
+    
+    if 'items' in video_response and video_response['items']:
+        return video_response['items'][0]
+    return None
+
+def get_all_videos():
+    """채널의 모든 동영상 정보 가져오기"""
+    uploads_playlist_id = get_channel_uploads()
+    if not uploads_playlist_id:
+        return []
+    
+    videos = []
+    next_page_token = None
+    
+    while True:
+        # 업로드 플레이리스트에서 영상 목록 가져오기
+        playlist_response = youtube.playlistItems().list(
+            part='snippet',
+            playlistId=uploads_playlist_id,
+            maxResults=50,
+            pageToken=next_page_token
+        ).execute()
+        
+        for item in playlist_response.get('items', []):
+            snippet = item['snippet']
+            video_id = snippet['resourceId']['videoId']
+            
+            # 영상 세부 정보 가져오기
+            video_details = get_video_details(video_id)
+            if video_details:
+                video_snippet = video_details['snippet']
+                videos.append({
+                    'id': video_id,
+                    'title': video_snippet['title'],
+                    'description': video_snippet['description'],
+                    'publishedAt': video_snippet['publishedAt'],
+                    'tags': video_snippet.get('tags', [])
+                })
+        
+        # 다음 페이지 토큰 확인
+        next_page_token = playlist_response.get('nextPageToken')
+        if not next_page_token:
+            break
+    
+    return videos
+
+def update_video_post(filepath, video, existing_post):
+    """기존 영상 포스트 업데이트"""
+    # 업데이트 필요 여부 확인
+    needs_update = False
+    
+    # 프론트매터 업데이트 점검
+    if existing_post.get('title') != video['title']:
+        existing_post['title'] = video['title']
+        needs_update = True
+    
+    if existing_post.get('tags') != video['tags']:
+        existing_post['tags'] = video['tags']
+        needs_update = True
+    
+    # 설명 변경 확인 (첫 줄만 비교)
+    old_desc = existing_post.get('description', '')
+    new_desc = video['description'].split('\n')[0] if video['description'] else ''
+    if old_desc != new_desc:
+        existing_post['description'] = new_desc
+        needs_update = True
+    
+    # 본문 콘텐츠 업데이트 (영상 설명)
+    new_content = f"""
+{{{{< youtube {video['id']} >}}}}
+
+{video['description']}
+"""
+    
+    if existing_post.content.strip() != new_content.strip():
+        existing_post.content = new_content
+        needs_update = True
+    
+    # 변경사항이 있으면 파일 저장
+    if needs_update:
+        with open(filepath, 'wb') as f:
+            frontmatter.dump(existing_post, f)
+        print(f"Updated post: {filepath.name}")
+        return True
+    
+    print(f"No updates needed for: {filepath.name}")
+    return False
+
+def create_or_update_video_post(video):
+    """영상 정보를 마크다운 포스트로 생성하거나 업데이트"""
+    # 게시일 파싱
+    published_date = datetime.datetime.fromisoformat(video['publishedAt'].replace('Z', '+00:00'))
+    published_date_kst = published_date.astimezone(KST)
+    date_str = published_date_kst.strftime('%Y-%m-%d')
+    
+    # 파일명 생성 (영상 ID 기반)
+    filename = f"{date_str}-{video['id']}.md"
+    filepath = VIDEOS_DIR / filename
+    
+    # ID 기반 파일명이 없는지 확인 (이전 버전과의 호환성)
+    if not filepath.exists():
+        # 제목 기반 파일명도 확인
+        legacy_filename = f"{date_str}-{sanitize_filename(video['title'])}.md"
+        legacy_filepath = VIDEOS_DIR / legacy_filename
+        
+        if legacy_filepath.exists():
+            # 기존 파일이 있으면 ID 기반 파일명으로 마이그레이션
+            existing_post = frontmatter.load(legacy_filepath)
+            if existing_post.get('youtube_id') == video['id']:
+                # 파일 이름 변경 (마이그레이션)
+                os.rename(legacy_filepath, filepath)
+                print(f"Migrated post filename to ID-based: {filename}")
+    
+    # 파일 존재 여부 확인
+    if filepath.exists():
+        # 기존 파일 업데이트
+        existing_post = frontmatter.load(filepath)
+        return update_video_post(filepath, video, existing_post)
+    else:
+        # 새 파일 생성
+        post_data = {
+            'title': video['title'],
+            'date': published_date_kst.strftime('%Y-%m-%d'),
+            'draft': False,
+            'youtube_id': video['id'],
+            'tags': video['tags'],
+            'categories': ['videos'],
+            'description': video['description'].split('\n')[0] if video['description'] else ''
+        }
+        
+        # 본문 작성
+        content = f"""
+{{{{< youtube {video['id']} >}}}}
+
+{video['description']}
+"""
+        
+        # 마크다운 파일 생성
+        post = frontmatter.Post(content, **post_data)
+        with open(filepath, 'wb') as f:
+            frontmatter.dump(post, f)
+        
+        print(f"Created new post: {filename}")
+        return True
+
+def main():
+    # 비디오 디렉토리 생성
+    VIDEOS_DIR.mkdir(exist_ok=True, parents=True)
+    
+    # 영상 목록 가져오기
+    videos = get_all_videos()
+    print(f"Found {len(videos)} videos")
+    
+    # 각 영상에 대해 포스트 생성 또는 업데이트
+    for video in videos:
+        create_or_update_video_post(video)
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/youtube-import.yml
+++ b/.github/workflows/youtube-import.yml
@@ -1,0 +1,39 @@
+name: Import YouTube Videos
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # 매일 자정에 실행
+  workflow_dispatch:  # 수동 실행도 가능하게 설정
+
+jobs:
+  import-videos:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # 전체 히스토리 가져오기
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install google-api-python-client pyyaml python-frontmatter pytz
+      
+      - name: Fetch YouTube videos
+        env:
+          YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
+          CHANNEL_ID: 'UCOt8sKxnjgZAM02Lc89Ijkw'  # @piesp 채널 ID
+        run: python .github/scripts/youtube-import.py
+      
+      - name: Commit changes
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add piesp-blog/content/videos/
+          git diff --quiet && git diff --staged --quiet || git commit -m "Update YouTube video posts"
+          git push

--- a/piesp-blog/config.toml
+++ b/piesp-blog/config.toml
@@ -34,6 +34,10 @@ paginate = 10
   [[params.socialIcons]]
   name = "GitHub"
   url = "https://github.com/PiesP"
+  
+  [[params.socialIcons]]
+  name = "YouTube"
+  url = "https://www.youtube.com/@piesp"
 
 [menu]
   [[menu.main]]
@@ -45,13 +49,18 @@ paginate = 10
     name = "Posts"
     url = "/posts/"
     weight = 2
+    
+  [[menu.main]]
+    name = "Videos"
+    url = "/videos/"
+    weight = 3
 
   [[menu.main]]
     name = "About"
     url = "/about/"
-    weight = 3
+    weight = 4
     
   [[menu.main]]
     name = "Search"
     url = "/search/"
-    weight = 4
+    weight = 5

--- a/piesp-blog/content/videos/_index.md
+++ b/piesp-blog/content/videos/_index.md
@@ -1,0 +1,6 @@
+---
+title: "YouTube 영상"
+description: "PiesP의 YouTube 채널 영상 목록"
+---
+
+제 YouTube 채널의 영상들입니다. 

--- a/piesp-blog/layouts/index.html
+++ b/piesp-blog/layouts/index.html
@@ -1,0 +1,67 @@
+{{ define "main" }}
+<main>
+  <!-- 최신 영상 한 개 고정 표시 -->
+  <div class="featured-video-container">
+    <h2>최신 영상</h2>
+    {{ $latest_video := (where .Site.RegularPages "Section" "videos").ByDate.Reverse | first 1 }}
+    {{ range $latest_video }}
+    <div class="featured-video">
+      <h3><a href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
+      <div class="video-container">
+        <iframe src="https://www.youtube.com/embed/{{ .Params.youtube_id }}" 
+          style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;" 
+          allowfullscreen title="YouTube Video"></iframe>
+      </div>
+      <div class="post-meta">
+        <span>{{ .Date.Format "2006-01-02" }}</span>
+      </div>
+    </div>
+    {{ end }}
+  </div>
+
+  <!-- 나머지 포스트 (영상 카테고리 제외) -->
+  <div class="posts">
+    <h2>최근 포스트</h2>
+    {{ $paginator := .Paginate (where .Site.RegularPages "Section" "posts") }}
+    {{ range $paginator.Pages }}
+    <article class="post-entry">
+      <header class="entry-header">
+        <h3>
+          <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+        </h3>
+      </header>
+      <div class="entry-content">
+        <p>{{ .Summary }}</p>
+      </div>
+      <footer class="entry-footer">
+        <span>{{ .Date.Format "2006-01-02" }}</span>
+      </footer>
+    </article>
+    {{ end }}
+  </div>
+
+  {{ partial "pagination.html" . }}
+</main>
+{{ end }}
+
+<style>
+.featured-video-container {
+  margin-bottom: 2rem;
+  padding: 1rem;
+  background-color: #f8f9fa;
+  border-radius: 5px;
+}
+
+.featured-video {
+  margin-bottom: 1rem;
+}
+
+.video-container {
+  position: relative;
+  width: 100%;
+  padding-bottom: 56.25%; /* 16:9 비율 */
+  height: 0;
+  overflow: hidden;
+  margin-bottom: 1rem;
+}
+</style>

--- a/piesp-blog/layouts/shortcodes/youtube.html
+++ b/piesp-blog/layouts/shortcodes/youtube.html
@@ -1,0 +1,15 @@
+<div class="video-container">
+  <iframe src="https://www.youtube.com/embed/{{ .Get 0 }}" 
+    style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;" 
+    allowfullscreen title="YouTube Video"></iframe>
+</div>
+<style>
+.video-container {
+  position: relative;
+  width: 100%;
+  padding-bottom: 56.25%; /* 16:9 비율 */
+  height: 0;
+  overflow: hidden;
+  margin-bottom: 1rem;
+}
+</style>

--- a/piesp-blog/layouts/videos/single.html
+++ b/piesp-blog/layouts/videos/single.html
@@ -1,0 +1,89 @@
+{{ define "main" }}
+<article class="post-single">
+  <header class="post-header">
+    <h1 class="post-title">{{ .Title }}</h1>
+    <div class="post-meta">
+      {{ if .Date }}
+      <span>{{ .Date.Format "2006-01-02" }}</span>
+      {{ end }}
+      {{ if .Params.tags }}
+      <span class="post-tags">
+        {{ range .Params.tags }}
+        <a href="{{ "/tags/" | relLangURL }}{{ . | urlize }}/">{{ . }}</a>
+        {{ end }}
+      </span>
+      {{ end }}
+    </div>
+  </header>
+
+  <div class="post-content">
+    {{ .Content }}
+  </div>
+
+  <!-- 영상 포스트 간 이동 -->
+  <div class="post-nav">
+    {{ $currentPage := . }}
+    {{ $pages := (where .Site.RegularPages "Section" "videos").ByDate.Reverse }}
+    {{ $pages_count := len $pages }}
+    {{ range $index, $page := $pages }}
+      {{ if eq $page $currentPage }}
+        <div class="post-nav-links">
+          {{ if ne $index 0 }}
+            {{ $prev := index $pages (sub $index 1) }}
+            <div class="post-nav-prev">
+              <a href="{{ $prev.RelPermalink }}">
+                <span>이전 영상</span><br>
+                <span>{{ $prev.Title }}</span>
+              </a>
+            </div>
+          {{ end }}
+          
+          {{ if ne (add $index 1) $pages_count }}
+            {{ $next := index $pages (add $index 1) }}
+            <div class="post-nav-next">
+              <a href="{{ $next.RelPermalink }}">
+                <span>다음 영상</span><br>
+                <span>{{ $next.Title }}</span>
+              </a>
+            </div>
+          {{ end }}
+        </div>
+      {{ end }}
+    {{ end }}
+  </div>
+
+  {{ if .Site.Params.ShowShareButtons }}
+    {{ partial "share_icons.html" . }}
+  {{ end }}
+</article>
+{{ end }}
+
+<style>
+.post-nav {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 2rem;
+}
+
+.post-nav-links {
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+}
+
+.post-nav-prev, .post-nav-next {
+  max-width: 48%;
+}
+
+.post-nav a {
+  display: block;
+  padding: 10px;
+  border: 1px solid #eee;
+  border-radius: 5px;
+  text-decoration: none;
+}
+
+.post-nav a:hover {
+  background-color: #f8f9fa;
+}
+</style>


### PR DESCRIPTION
1. YouTube Data API를 사용하여 채널 영상 가져오기
2. 영상 데이터로 블로그 포스트 자동 생성
3. 홈페이지에 최신 영상 표시
4. 영상과 일반 포스트 카테고리 분리
5. 영상 간 이동 네비게이션 구현