### PR TITLE
블로그 레이아웃 및 설정 수정

### DIFF
--- a/piesp-blog/config.toml
+++ b/piesp-blog/config.toml
@@ -6,7 +6,9 @@ defaultContentLanguage = "ko"
 enableRobotsTXT = true
 publishDir = "public"
 
-paginate = 10
+# 더 이상 사용되지 않는 paginate 대신 pagination 사용
+[pagination]
+  pagerSize = 10
 
 [outputs]
   home = ["HTML", "RSS", "JSON", "sitemap"]

--- a/piesp-blog/layouts/_default/list.json
+++ b/piesp-blog/layouts/_default/list.json
@@ -1,0 +1,37 @@
+{
+    "version": "https://jsonfeed.org/version/1",
+    "title": "{{ .Site.Title }}",
+    "home_page_url": "{{ .Site.BaseURL }}",
+    "feed_url": "{{ .Permalink }}",
+    "description": "{{ .Site.Params.description | default .Site.Title }}",
+    "items": [
+        {{- $pages := where .RegularPages "Type" "in" .Site.Params.mainSections -}}
+        {{- $limit := .Site.Config.Services.RSS.Limit -}}
+        {{- if ge $limit 1 -}}
+            {{- $pages = $pages | first $limit -}}
+        {{- end -}}
+        
+        {{- $last := sub (len $pages) 1 -}}
+        {{- range $i, $page := $pages -}}
+            {
+                "id": "{{ $page.Permalink }}",
+                "url": "{{ $page.Permalink }}",
+                "title": "{{ $page.Title }}",
+                "content_html": {{ $page.Content | jsonify }},
+                "date_published": "{{ $page.Date.Format "2006-01-02T15:04:05Z07:00" }}"
+                {{- if $page.Params.author -}}
+                , "author": {
+                  "name": "{{ $page.Params.author }}"
+                  }
+                {{- end -}}
+                {{- if $page.Params.tags -}}
+                , "tags": [
+                  {{- range $j, $tag := $page.Params.tags -}}
+                    "{{ $tag }}"{{ if ne $j (sub (len $page.Params.tags) 1) }},{{ end }}
+                  {{- end -}}
+                ]
+                {{- end -}}
+            }{{ if ne $i $last }},{{ end }}
+        {{- end -}}
+    ]
+}

--- a/piesp-blog/layouts/_default/sitemap.xml
+++ b/piesp-blog/layouts/_default/sitemap.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {{ range .Data.Pages }}
@@ -9,12 +9,12 @@
     <priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .Translations }}
     <xhtml:link
                 rel="alternate"
-                hreflang="{{ .Lang }}"
+                hreflang="{{ .Language.Lang }}"
                 href="{{ .Permalink }}"
                 />{{ end }}
     <xhtml:link
                 rel="alternate"
-                hreflang="{{ .Lang }}"
+                hreflang="{{ .Language.Lang }}"
                 href="{{ .Permalink }}"
                 />{{ end }}
   </url>

--- a/piesp-blog/layouts/partials/home-info.html
+++ b/piesp-blog/layouts/partials/home-info.html
@@ -1,0 +1,54 @@
+{{- with site.Params.homeInfoParams }}
+<article class="first-entry home-info">
+    <header class="entry-header">
+        <h1>{{ .Title | markdownify }}</h1>
+    </header>
+    <div class="entry-content">
+        {{ .Content | markdownify }}
+    </div>
+    <footer class="entry-footer">
+        {{ partial "social_icons.html" site.Params.socialIcons }}
+    </footer>
+</article>
+{{- end -}}
+
+<!-- 최신 영상 한 개 고정 표시 -->
+<div class="featured-video-container">
+    <h2>최신 영상</h2>
+    {{ $latest_video := (where site.RegularPages "Section" "videos").ByDate.Reverse | first 1 }}
+    {{ range $latest_video }}
+    <div class="featured-video">
+        <h3><a href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
+        <div class="video-container">
+            <iframe src="https://www.youtube.com/embed/{{ .Params.youtube_id }}" 
+                style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;" 
+                allowfullscreen title="YouTube Video"></iframe>
+        </div>
+        <div class="post-meta">
+            <span>{{ .Date.Format "2006-01-02" }}</span>
+        </div>
+    </div>
+    {{ end }}
+</div>
+
+<style>
+.featured-video-container {
+    margin-bottom: 2rem;
+    padding: 1rem;
+    background-color: var(--entry);
+    border-radius: var(--radius);
+}
+
+.featured-video {
+    margin-bottom: 1rem;
+}
+
+.video-container {
+    position: relative;
+    width: 100%;
+    padding-bottom: 56.25%; /* 16:9 비율 */
+    height: 0;
+    overflow: hidden;
+    margin-bottom: 1rem;
+}
+</style>


### PR DESCRIPTION
1. config.toml에서 deprecated된 paginate 설정을 pagination.pagerSize로 변경
2. 필요한 레이아웃 파일 추가 (list.json, home-info.html)
3. 영상 표시 기능을 home-info.html로 이동하여 테마 호환성 개선